### PR TITLE
feat: Add a `--generate` option for generating a brand-new config file with a default `release` workflow.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "thiserror",
  "toml",
  "ureq",
+ "velcro",
 ]
 
 [[package]]
@@ -1127,6 +1128,36 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "velcro"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85554e2a4b7527966b335b31c7c525e1dd6531cbf41b63470c952da53b7e07bf"
+dependencies = [
+ "velcro_macros",
+]
+
+[[package]]
+name = "velcro_core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99125cbb1d0dc3ac382bc77cea20335e8608998bd03f7232ac870adf23b0d498"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "velcro_macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d6cb3e9601d03fc75e39bf0515373162cc8a3e2bbfe8836709bb1ede341904"
+dependencies = [
+ "syn",
+ "velcro_core",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap = { version = "3.1.6", features = ["cargo", "derive"] }
 itertools = "0.10.3"
 miette = { version = "4.2.1", features = ["fancy"] }
 thiserror = "1.0.30"
+velcro = "0.5.3"
 
 [dev-dependencies]
 snapbox = "0.2.9"

--- a/dobby.toml
+++ b/dobby.toml
@@ -15,13 +15,6 @@ name = "Finish Development"
     command = "gh pr create --web -p WIP"
 
 [[workflows]]
-name = "dry-release"
-
-    [[workflows.steps]]
-    type = "PrepareRelease"
-    dry_run = true
-
-[[workflows]]
 name = "release"
 
     [[workflows.steps]]

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -18,8 +18,9 @@ There are a few options you can pass to `dobby` to control how it behaves.
 
 1. `--help` prints out a help message and exits.
 2. `--version` prints out the version of `dobby` and exits.
-3. `--validate` will check your `dobby.toml` to make sure every workflow in it is valid, then exit. This could be useful to run in CI to make sure that your config is always valid. The exit code of this command will be 0 only if the config is valid.
-4. `--dry-run` will pretend to run the selected workflow (either via arg or prompt), but will not actually perform any work (e.g., external commands, file I/O, API calls). Detects the same errors as `--validate` but also outputs info about what _would_ happen to stdout.
+3. `--generate` will generate a `dobby.toml` file in the current directory.
+4. `--validate` will check your `dobby.toml` to make sure every workflow in it is valid, then exit. This could be useful to run in CI to make sure that your config is always valid. The exit code of this command will be 0 only if the config is valid.
+5. `--dry-run` will pretend to run the selected workflow (either via arg or prompt), but will not actually perform any work (e.g., external commands, file I/O, API calls). Detects the same errors as `--validate` but also outputs info about what _would_ happen to stdout.
 
 ## Features
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use execute::shell;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::git::branch_name_from_issue;
 use crate::releases::get_version;
@@ -9,7 +9,7 @@ use crate::step::StepError;
 use crate::{state, RunType, State};
 
 /// Describes a value that you can replace an arbitrary string with when running a command.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) enum Variable {
     /// Uses the first supported version found in your project.
     Version,

--- a/src/git.rs
+++ b/src/git.rs
@@ -95,6 +95,16 @@ pub(crate) fn select_issue_from_current_branch(run_type: RunType) -> Result<RunT
     }
 }
 
+/// Get the first remote of the Git repo, if any.
+pub(crate) fn get_first_remote() -> Option<String> {
+    let repo = Repository::open(".").ok()?;
+    let remotes = repo.remotes().ok()?;
+    let remote_name = remotes.get(0)?;
+    repo.find_remote(remote_name)
+        .ok()
+        .and_then(|remote| remote.url().map(String::from))
+}
+
 fn select_issue_from_branch_name(ref_name: &str) -> Result<Issue, StepError> {
     let parts: Vec<&str> = ref_name.split('-').collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,11 @@ mod workflow;
 /// 3. Selected workflow not found
 /// 4. Passthrough errors of selected workflow
 pub fn run(cli: Cli) -> Result<()> {
+    if cli.generate {
+        println!("Generating a dobby.toml file");
+        return config::generate();
+    }
+
     let preselected_workflow = cli.workflow;
 
     let config = Config::load()?;
@@ -93,6 +98,10 @@ pub struct Cli {
     #[clap(long)]
     /// Pretend to run a workflow, outputting what _would_ happen without actually doing it.
     dry_run: bool,
+
+    #[clap(long)]
+    /// Generate a new `dobby.toml` file.
+    generate: bool,
 }
 
 #[cfg(test)]

--- a/src/releases/semver.rs
+++ b/src/releases/semver.rs
@@ -1,14 +1,14 @@
 use std::fmt::Display;
 
 use semver::{Prerelease, Version};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::step::StepError;
 use crate::{package_json, pyproject, state, RunType};
 
 /// The various rules that can be used when bumping the current version of a project via
 /// [`crate::step::Step::BumpVersion`].
-#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(tag = "rule")]
 pub(crate) enum Rule {
     Major,
@@ -16,7 +16,7 @@ pub(crate) enum Rule {
     Patch,
     Pre {
         label: String,
-        #[serde(skip_deserializing)]
+        #[serde(skip)]
         fallback_rule: ConventionalRule,
     },
     Release,

--- a/src/step.rs
+++ b/src/step.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use miette::Diagnostic;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::state::RunType;
@@ -9,7 +9,7 @@ use crate::{command, git, issues, releases};
 
 /// Each variant describes an action you can take using Dobby, they are used when defining your
 /// [`crate::Workflow`] via whatever config format is being utilized.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 #[serde(tag = "type")]
 pub(crate) enum Step {
     /// Search for Jira issues by status and display the list of them in the terminal.
@@ -280,7 +280,7 @@ pub(super) enum StepError {
 }
 
 /// The inner content of a [`Step::PrepareRelease`] step.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct PrepareRelease {
     #[serde(default = "default_changelog")]
     pub(crate) changelog_path: String,

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -3,7 +3,7 @@ use std::io::sink;
 
 use itertools::Itertools;
 use miette::Diagnostic;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::state::RunType;
@@ -11,7 +11,7 @@ use crate::step::{Step, StepError};
 use crate::State;
 
 /// A workflow is basically the state machine to run for a single execution of Dobby.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 pub(crate) struct Workflow {
     /// The display name of this Workflow. This is what you'll see when you go to select it.
     pub(crate) name: String,

--- a/tests/generate_github/dobby.toml
+++ b/tests/generate_github/dobby.toml
@@ -1,0 +1,16 @@
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+changelog_path = "CHANGELOG.md"
+
+[[workflows.steps]]
+type = "Command"
+command = "git add . && git commit -m \"chore: prepare release $version\" && git push"
+
+[workflows.steps.variables]
+"$version" = "Version"
+
+[[workflows.steps]]
+type = "Release"

--- a/tests/generate_no_remote/dobby.toml
+++ b/tests/generate_no_remote/dobby.toml
@@ -1,0 +1,13 @@
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+changelog_path = "CHANGELOG.md"
+
+[[workflows.steps]]
+type = "Command"
+command = "git add . && git commit -m \"chore: prepare release $version\" && git push && git tag -m $version && git push --tags"
+
+[workflows.steps.variables]
+"$version" = "Version"

--- a/tests/git_repo_helpers/mod.rs
+++ b/tests/git_repo_helpers/mod.rs
@@ -40,6 +40,23 @@ pub fn init(path: &Path) {
     );
 }
 
+/// Add a Git remote to the repo at `path`.
+pub fn add_remote(path: &Path, remote: &str) {
+    let output = Command::new("git")
+        .arg("remote")
+        .arg("add")
+        .arg("origin")
+        .arg(remote)
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// Create a commit with `message` in the Git repo which exists in `path`.
 pub fn commit(path: &Path, message: &str) {
     let output = Command::new("git")

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -8,6 +8,56 @@ use git_repo_helpers::*;
 
 mod git_repo_helpers;
 
+/// Run `--generate` on a repo with no remote.
+#[test]
+fn generate_no_remote() {
+    // Arrange
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let source_path = Path::new("tests/generate_no_remote");
+    init(temp_path);
+
+    // Act
+    let assert = Command::new(cargo_bin!("dobby"))
+        .arg("--generate")
+        .current_dir(temp_path)
+        .assert();
+
+    // Assert
+    assert.success().stdout_eq("Generating a dobby.toml file\n");
+    assert_eq_path(
+        source_path.join("dobby.toml"),
+        read_to_string(temp_path.join("dobby.toml")).unwrap(),
+    );
+}
+
+/// Run `--generate` on a repo with a GitHub remote.
+#[test]
+fn generate_github() {
+    // Arrange
+    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_path = temp_dir.path();
+    let source_path = Path::new("tests/generate_github");
+    init(temp_path);
+    add_remote(temp_path, "github.com/dobby-dev/dobby");
+
+    // Act
+    let assert = Command::new(cargo_bin!("dobby"))
+        .arg("--generate")
+        .current_dir(temp_path)
+        .assert();
+
+    // Assert
+    assert
+        .success()
+        .stdout_eq("Generating a dobby.toml file\n")
+        .stderr_eq("");
+    assert_eq_path(
+        source_path.join("dobby.toml"),
+        read_to_string(temp_path.join("dobby.toml")).unwrap(),
+    );
+}
+
 /// Run `--validate` with a config file that has lots of problems.
 #[test]
 fn test_validate() {


### PR DESCRIPTION
Closes #26